### PR TITLE
Fix minimap tile color mask

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/MiniMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MiniMapGump.cs
@@ -314,7 +314,7 @@ namespace ClassicUO.Game.UI.Gumps
                         for (int y = 0; y < 8; y++)
                         {
                             ref readonly var cell = ref cells[(y << 3) + x];
-                            int color = cell.TileID;
+                            int color = cell.TileID & 0x3FFF;
                             bool isLand = true;
                             int z = cell.Z;
 


### PR DESCRIPTION
## Summary
- fix minimap's color calculation when tile IDs exceed 0x3FFF

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850e708cfdc832fbecdeb5db7bdef03