### PR TITLE
Add Windows build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ Or visit the [ClassicUO Website](https://www.classicuo.eu/)
 ```
 git clone --recursive https://github.com/ClassicUO/ClassicUO.git
 cd ClassicUO/scripts
-bash build-naot.sh
+bash build-naot.sh  # Linux/macOS
+build-naot.cmd      # Windows
 ```
 Binaries available in `bin/dist` folder
-> [!WARNING] 
-> To execute .sh scripts on Windows, use Git Bash which can be installed with Git itself: https://git-scm.com/download/win
+> [!WARNING]
+> Windows users can run `build-naot.cmd`. If you prefer running the `.sh` script, use Git Bash which can be installed with Git itself: https://git-scm.com/download/win
 
 # Contribute
 Everyone is welcome to contribute! The GitHub issues and project tracker are kept up to date with tasks that need work.

--- a/scripts/build-naot.cmd
+++ b/scripts/build-naot.cmd
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+rem Define paths and project details
+set "bootstrap_project=..\src\ClassicUO.Bootstrap\src\ClassicUO.Bootstrap.csproj"
+set "client_project=..\src\ClassicUO.Client"
+set "output_directory=..\bin\dist"
+set "target="
+
+rem Determine the platform
+if /I "%OS%"=="Windows_NT" (
+    set "target=win-x64"
+) else (
+    echo Unsupported platform: %OS%
+    exit /b 1
+)
+
+
+dotnet publish "%bootstrap_project%" -c Release -o "%output_directory%"
+dotnet publish "%client_project%" -c Release -p:NativeLib=Shared -p:OutputType=Library -r %target% -o "%output_directory%"
+
+endlocal
+


### PR DESCRIPTION
## Summary
- add `build-naot.cmd` for running the native AOT build on Windows
- document usage in README and mention the new script as an alternative

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ebbc42ac832f9cd5c954d0da46a7