### PR TITLE
Add dark fog overlay option

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -166,6 +166,7 @@ namespace ClassicUO.Configuration
         public int LightLevelType { get; set; } // 0 = absolute, 1 = minimum
         public bool UseColoredLights { get; set; } = true;
         public bool UseDarkNights { get; set; }
+        public bool UseDarkFog { get; set; }
         public int CloseHealthBarType { get; set; } // 0 = none, 1 == not exists, 2 == is dead
         public bool ActivateChatAfterEnter { get; set; }
         public bool ActivateChatAdditionalButtons { get; set; } = true;

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1023,6 +1023,18 @@ namespace ClassicUO.Game.Scenes
             DrawSelection(batcher);
             batcher.End();
 
+            if (ProfileManager.CurrentProfile.UseDarkFog)
+            {
+                batcher.Begin();
+                Vector3 fogHue = ShaderHueTranslator.GetHueVector(0, false, 0.7f);
+                batcher.Draw(
+                    SolidColorTextureCache.GetTexture(Color.Black),
+                    new Rectangle(0, 0, Camera.Bounds.Width, Camera.Bounds.Height),
+                    fogHue
+                );
+                batcher.End();
+            }
+
             batcher.GraphicsDevice.Viewport = r_viewport;
 
             return base.Draw(batcher);

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -138,7 +138,7 @@ namespace ClassicUO.Game.UI.Gumps
         private NiceButton _setAsNewDefault;
 
         // video
-        private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _partyAura, _hideChatGradient, _animatedWaterEffect;
+        private Checkbox _use_old_status_gump, _statusGumpBarMutuallyExclusive, _windowBorderless, _enableDeathScreen, _enableBlackWhiteEffect, _altLights, _enableLight, _enableShadows, _enableShadowsStatics, _auraMouse, _runMouseInSeparateThread, _useColoredLights, _darkNights, _darkFog, _partyAura, _hideChatGradient, _animatedWaterEffect;
         private Combobox _lightLevelType;
         private Checkbox _use_smooth_boat_movement;
         private HSliderBar _terrainShadowLevel;
@@ -1828,6 +1828,18 @@ namespace ClassicUO.Game.UI.Gumps
                     null,
                     ResGumps.DarkNights,
                     _currentProfile.UseDarkNights,
+                    startX,
+                    startY
+                )
+            );
+
+            section3.Add
+            (
+                _darkFog = AddCheckBox
+                (
+                    null,
+                    ResGumps.DarkFog,
+                    _currentProfile.UseDarkFog,
                     startX,
                     startY
                 )
@@ -3655,6 +3667,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _lightLevelType.SelectedIndex = 0;
                     _useColoredLights.IsChecked = false;
                     _darkNights.IsChecked = false;
+                    _darkFog.IsChecked = false;
                     _enableShadows.IsChecked = true;
                     _enableShadowsStatics.IsChecked = true;
                     _terrainShadowLevel.Value = 15;
@@ -4064,6 +4077,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.UseColoredLights = _useColoredLights.IsChecked;
             _currentProfile.UseDarkNights = _darkNights.IsChecked;
+            _currentProfile.UseDarkFog = _darkFog.IsChecked;
             _currentProfile.ShadowsEnabled = _enableShadows.IsChecked;
             _currentProfile.ShadowsStatics = _enableShadowsStatics.IsChecked;
             _currentProfile.TerrainShadowsLevel = _terrainShadowLevel.Value;

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -1225,6 +1225,17 @@ namespace ClassicUO.Resources
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Dark fog.
+        /// </summary>
+        public static string DarkFog
+        {
+            get
+            {
+                return ResourceManager.GetString("DarkFog", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Data.
         /// </summary>
         public static string Data

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -453,6 +453,9 @@
   <data name="DarkNights" xml:space="preserve">
     <value>Dark nights</value>
   </data>
+  <data name="DarkFog" xml:space="preserve">
+    <value>Dark fog</value>
+  </data>
   <data name="UseColoredLights" xml:space="preserve">
     <value>Use colored lights</value>
   </data>


### PR DESCRIPTION
## Summary
- add `UseDarkFog` setting to profiles
- expose dark fog checkbox in OptionsGump and default resets
- localise DarkFog text in resources
- draw a black overlay when the option is enabled

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ae8fdac832f84e7ad898eccccde