### PR TITLE
Remove console window on startup

### DIFF
--- a/src/ClassicUO.Bootstrap/src/ClassicUO.Bootstrap.csproj
+++ b/src/ClassicUO.Bootstrap/src/ClassicUO.Bootstrap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>Preview</LangVersion>


### PR DESCRIPTION
## Summary
- compile the bootstrap executable as WinExe so no console window appears on startup

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540d1d4bac832fabd61819b1c652f0