### PR TITLE
Add moving dark fog smoke effect

### DIFF
--- a/src/ClassicUO.Client/Game/Effects/DarkFogEffect.cs
+++ b/src/ClassicUO.Client/Game/Effects/DarkFogEffect.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ClassicUO.Game.Effects
+{
+    internal sealed class DarkFogEffect
+    {
+        private readonly List<FogParticle> _particles = new List<FogParticle>();
+        private readonly Random _random = new Random();
+        private Texture2D _texture;
+
+        private Texture2D GetTexture(GraphicsDevice device)
+        {
+            if (_texture == null || _texture.IsDisposed)
+            {
+                const int size = 64;
+                _texture = new Texture2D(device, size, size);
+                var data = new Color[size * size];
+                float radius = size / 2f;
+
+                for (int y = 0; y < size; y++)
+                {
+                    for (int x = 0; x < size; x++)
+                    {
+                        float dx = x - radius;
+                        float dy = y - radius;
+                        float dist = MathF.Sqrt(dx * dx + dy * dy);
+                        float alpha = Math.Clamp(1f - dist / radius, 0f, 1f);
+                        data[y * size + x] = new Color(0f, 0f, 0f, alpha);
+                    }
+                }
+
+                _texture.SetData(data);
+            }
+
+            return _texture;
+        }
+
+        public void Update(int width, int height)
+        {
+            if (_particles.Count < 20)
+            {
+                SpawnParticle(width, height);
+            }
+
+            float dt = Time.Delta;
+            for (int i = 0; i < _particles.Count; i++)
+            {
+                FogParticle p = _particles[i];
+                p.Position += p.Velocity * dt;
+                p.Alpha -= dt * 0.05f;
+
+                if (p.Alpha <= 0)
+                {
+                    _particles.RemoveAt(i--);
+                }
+                else
+                {
+                    _particles[i] = p;
+                }
+            }
+        }
+
+        private void SpawnParticle(int width, int height)
+        {
+            float x = _random.Next(width);
+            float y = _random.Next(height);
+            float angle = (float)(_random.NextDouble() * Math.PI * 2);
+            float speed = 10f + (float)_random.NextDouble() * 20f;
+            Vector2 vel = new Vector2(MathF.Cos(angle) * speed, MathF.Sin(angle) * speed);
+            float scale = 0.5f + (float)_random.NextDouble();
+            float alpha = 0.3f + (float)_random.NextDouble() * 0.2f;
+
+            _particles.Add(new FogParticle { Position = new Vector2(x, y), Velocity = vel, Alpha = alpha, Scale = scale });
+        }
+
+        public void Draw(UltimaBatcher2D batcher)
+        {
+            Texture2D tex = GetTexture(batcher.GraphicsDevice);
+
+            foreach (ref readonly FogParticle p in _particles)
+            {
+                Vector3 hue = ShaderHueTranslator.GetHueVector(0, false, p.Alpha);
+                int size = (int)(tex.Width * p.Scale);
+                var dest = new Rectangle((int)p.Position.X - size / 2, (int)p.Position.Y - size / 2, size, size);
+                batcher.Draw(tex, dest, hue);
+            }
+        }
+
+        private struct FogParticle
+        {
+            public Vector2 Position;
+            public Vector2 Velocity;
+            public float Alpha;
+            public float Scale;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -8,6 +8,7 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Effects;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
@@ -68,6 +69,7 @@ namespace ClassicUO.Game.Scenes
         private bool _useObjectHandles;
         private RenderTarget2D _world_render_target, _lightRenderTarget;
         private AnimatedStaticsManager _animatedStaticsManager;
+        private DarkFogEffect _darkFogEffect;
 
         private readonly World _world;
 
@@ -111,6 +113,7 @@ namespace ClassicUO.Game.Scenes
             _world.Macros.Load();
             _animatedStaticsManager = new AnimatedStaticsManager();
             _animatedStaticsManager.Initialize();
+            _darkFogEffect = new DarkFogEffect();
             _world.InfoBars.Load();
             _healthLinesManager = new HealthLinesManager(_world);
 
@@ -901,10 +904,15 @@ namespace ClassicUO.Game.Scenes
                     if (SelectedObject.Object is Item it && GameActions.PickUp(_world, it.Serial, 0, 0))
                     {
                         _isMouseLeftDown = false;
-                        _holdMouse2secOverItemTime = 0;
-                    }
+                    _holdMouse2secOverItemTime = 0;
                 }
             }
+
+            if (ProfileManager.CurrentProfile.UseDarkFog)
+            {
+                _darkFogEffect.Update(Camera.Bounds.Width, Camera.Bounds.Height);
+            }
+        }
         }
 
         public override bool Draw(UltimaBatcher2D batcher)
@@ -1032,6 +1040,7 @@ namespace ClassicUO.Game.Scenes
                     new Rectangle(0, 0, Camera.Bounds.Width, Camera.Bounds.Height),
                     fogHue
                 );
+                _darkFogEffect.Draw(batcher);
                 batcher.End();
             }
 


### PR DESCRIPTION
## Summary
- implement `DarkFogEffect` for animated smoke
- use the new effect in `GameScene` when dark fog is enabled

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685426e082fc832fa7df593ee9f0fcfd