### PR TITLE
Add animation speed setting

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -129,6 +129,7 @@ namespace ClassicUO.Configuration
         public bool BandageSelfOld { get; set; } = true;
         public bool EnableDeathScreen { get; set; } = true;
         public bool EnableBlackWhiteEffect { get; set; } = true;
+        public int AnimationFrameDelay { get; set; } = Constants.CHARACTER_ANIMATION_DELAY;
 
         // tooltip
         public bool UseTooltip { get; set; } = true;

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -540,7 +540,7 @@ namespace ClassicUO.Game.GameObjects
                     }
                 }
 
-                LastAnimationChangeTime = Time.Ticks + Constants.CHARACTER_ANIMATION_DELAY;
+                LastAnimationChangeTime = Time.Ticks + ProfileManager.CurrentProfile.AnimationFrameDelay;
             }
         }
     }

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -579,7 +579,7 @@ namespace ClassicUO.Game.GameObjects
 
             bool mirror = false;
             animations.GetAnimDirection(ref dir, ref mirror);
-            int currentDelay = Constants.CHARACTER_ANIMATION_DELAY;
+            int currentDelay = ProfileManager.CurrentProfile.AnimationFrameDelay;
 
             if (id < animations.MaxAnimationCount && dir < 5)
             {
@@ -767,8 +767,8 @@ namespace ClassicUO.Game.GameObjects
                         }
                         else
                         {
-                            float steps = maxDelay / (float)Constants.CHARACTER_ANIMATION_DELAY;
-                            float x = delay / (float)Constants.CHARACTER_ANIMATION_DELAY;
+                            float steps = maxDelay / (float)ProfileManager.CurrentProfile.AnimationFrameDelay;
+                            float x = delay / (float)ProfileManager.CurrentProfile.AnimationFrameDelay;
                             float y = x;
                             Offset.Z = (sbyte)((step.Z - Z) * x * (4.0f / steps));
                             MovementSpeed.GetPixelOffset(step.Direction, ref x, ref y, steps);

--- a/src/ClassicUO.Client/Game/Managers/BoatMovingManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BoatMovingManager.cs
@@ -240,8 +240,8 @@ namespace ClassicUO.Game.Managers
                     {
                         if (maxDelay != 0)
                         {
-                            float steps = maxDelay / (float) Constants.CHARACTER_ANIMATION_DELAY;
-                            float x = delay / (float) Constants.CHARACTER_ANIMATION_DELAY;
+                            float steps = maxDelay / (float) ProfileManager.CurrentProfile.AnimationFrameDelay;
+                            float x = delay / (float) ProfileManager.CurrentProfile.AnimationFrameDelay;
                             float y = x;
                             item.Offset.Z = (sbyte) ((step.Z - item.Z) * x * (4.0f / steps));
                             MovementSpeed.GetPixelOffset((byte) step.MovingDir, ref x, ref y, steps);

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -127,6 +127,7 @@ namespace ClassicUO.Game.UI.Gumps
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
         private HSliderBar _sliderSpeechDelay;
+        private HSliderBar _sliderAnimationDelay;
         private HSliderBar _sliderZoom;
         private HSliderBar _soundsVolume, _musicVolume, _loginMusicVolume;
         private ClickableColorBox _speechColorPickerBox, _emoteColorPickerBox, _yellColorPickerBox, _whisperColorPickerBox, _partyMessageColorPickerBox, _guildMessageColorPickerBox, _allyMessageColorPickerBox, _chatMessageColorPickerBox, _partyAuraColorPickerBox;
@@ -1353,7 +1354,7 @@ namespace ClassicUO.Game.UI.Gumps
 
 
             SettingsSection section5 = AddSettingsSection(box, "Terrain & Statics");
-            section5.Y = section4.Bounds.Bottom + 40;
+            section5.Y = animSection.Bounds.Bottom + 40;
 
             section5.Add
             (
@@ -1921,9 +1922,27 @@ namespace ClassicUO.Game.UI.Gumps
                 )
             );
 
+            SettingsSection animSection = AddSettingsSection(box, "Animations");
+            animSection.Y = section4.Bounds.Bottom + 40;
+            animSection.Add(AddLabel(null, ResGumps.AnimationFrameDelay, startX, startY));
+            animSection.AddRight
+            (
+                _sliderAnimationDelay = AddHSlider
+                (
+                    null,
+                    20,
+                    200,
+                    _currentProfile.AnimationFrameDelay,
+                    startX,
+                    startY,
+                    180
+                )
+            );
+
+
 
             SettingsSection section5 = AddSettingsSection(box, "Shadows");
-            section5.Y = section4.Bounds.Bottom + 40;
+            section5.Y = animSection.Bounds.Bottom + 40;
 
             section5.Add
             (
@@ -3676,6 +3695,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _partyAura.IsChecked = true;
                     _animatedWaterEffect.IsChecked = false;
                     _partyAuraColorPickerBox.Hue = 0x0044;
+                    _sliderAnimationDelay.Value = Constants.CHARACTER_ANIMATION_DELAY;
 
                     break;
 
@@ -4087,8 +4107,10 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.AuraOnMouse = _auraMouse.IsChecked;
             _currentProfile.AnimatedWaterEffect = _animatedWaterEffect.IsChecked;
+            _currentProfile.AnimationFrameDelay = _sliderAnimationDelay.Value;
             _currentProfile.PartyAura = _partyAura.IsChecked;
             _currentProfile.PartyAuraHue = _partyAuraColorPickerBox.Hue;
+                    _sliderAnimationDelay.Value = Constants.CHARACTER_ANIMATION_DELAY;
             _currentProfile.HideChatGradient = _hideChatGradient.IsChecked;
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -345,6 +345,17 @@ namespace ClassicUO.Resources
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Animation frame delay.
+        /// </summary>
+        public static string AnimationFrameDelay
+        {
+            get
+            {
+                return ResourceManager.GetString("AnimationFrameDelay", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Anisotropic Clamp.
         /// </summary>
         public static string AnisotropicClamp

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -489,6 +489,9 @@
   <data name="AnimatedWaterEffect" xml:space="preserve">
     <value>Animated water effect</value>
   </data>
+  <data name="AnimationFrameDelay" xml:space="preserve">
+    <value>Animation frame delay</value>
+  </data>
   <data name="UseXBREffectBETA" xml:space="preserve">
     <value>Use xBR effect [BETA]</value>
   </data>


### PR DESCRIPTION
## Summary
- allow customizing animation frame delay in user profiles
- expose an animation speed slider in the video options
- apply new delay when updating mobiles, boats and corpses
- add resource string for the new option

## Testing
- `dotnet test -c Release` *(fails: NETSDK1045 targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68545bce014c832f93d4a7bf30e4fd29