### PR TITLE
Fix animation delay slider

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -4110,7 +4110,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.AnimationFrameDelay = _sliderAnimationDelay.Value;
             _currentProfile.PartyAura = _partyAura.IsChecked;
             _currentProfile.PartyAuraHue = _partyAuraColorPickerBox.Hue;
-            _sliderAnimationDelay.Value = Constants.Character_Animation_Delay;
+            _sliderAnimationDelay.Value = _currentProfile.AnimationFrameDelay;
             _currentProfile.HideChatGradient = _hideChatGradient.IsChecked;
             _currentProfile.IgnoreGuildMessages = _ignoreGuildMessages.IsChecked;
             _currentProfile.IgnoreAllianceMessages = _ignoreAllianceMessages.IsChecked;


### PR DESCRIPTION
## Summary
- keep animation delay slider in sync with chosen value

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685460dbd808832fb5e50778d6e3ee80