### PR TITLE
Fix footstep audio timing

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -534,22 +534,24 @@ namespace ClassicUO.Game.GameObjects
 
                     int incID = StepSoundOffset;
                     int soundID = 0x012B;
-                    int delaySound = 400;
+                    int delaySound = step.Run ? MovementSpeed.STEP_DELAY_RUN : MovementSpeed.STEP_DELAY_WALK;
 
                     if (IsMounted)
                     {
                         if (step.Run)
                         {
                             soundID = 0x0129;
-                            delaySound = 150;
+                            delaySound = MovementSpeed.STEP_DELAY_MOUNT_RUN;
                         }
                         else
                         {
                             incID = 0;
-                            delaySound = 350;
+                            delaySound = MovementSpeed.STEP_DELAY_MOUNT_WALK;
                         }
                     }
 
+                    float factor = ProfileManager.CurrentProfile.AnimationFrameDelay / (float)Constants.Character_Animation_Delay;
+                    delaySound = (int) (delaySound * factor);
                     delaySound = delaySound * 13 / 10;
 
                     soundID += incID;


### PR DESCRIPTION
## Summary
- sync footstep sound delay with current animation speed

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685462dce9c4832f9f446dd912566dc2