### PR TITLE
Fix crash on logout due to null profile

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -336,7 +336,7 @@ namespace ClassicUO.Game.Scenes
             _useItemQueue?.Clear();
             _world.MessageManager.MessageReceived -= ChatOnMessageReceived;
 
-            if (ProfileManager.CurrentProfile.UseDarkFog)
+            if (ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.UseDarkFog)
             {
                 // _darkFogEffect.Update(Camera.Bounds.Width, Camera.Bounds.Height);
                 // _thunderEffect.Update(Camera.Bounds.Width, Camera.Bounds.Height);


### PR DESCRIPTION
## Summary
- guard against null `CurrentProfile` after unloading profile

## Testing
- `dotnet test --no-build -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e2d2dac0832f9b66d0fbefde89ce