### PR TITLE
Add linux-only build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Paths and project details
+bootstrap_project="../src/ClassicUO.Bootstrap/src/ClassicUO.Bootstrap.csproj"
+client_project="../src/ClassicUO.Client"
+output_directory="../bin/dist"
+
+# Target platform for Linux
+target="linux-x64"
+
+dotnet publish "$bootstrap_project" -c Release -o "$output_directory"
+dotnet publish "$client_project" -c Release -p:NativeLib=Shared -p:OutputType=Library -r "$target" -o "$output_directory"
+


### PR DESCRIPTION
## Summary
- add `build.sh` which compiles ClassicUO on Linux only

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4dc067c832fbb05aab1210831a1